### PR TITLE
Remove aliases sh references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ cd ~/podman/regtest-in-a-pod/
 podman machine start regtest
 podman --connection regtest build --tag localhost/regtest:v1.0.0 --file ./Containerfile
 podman create --name RegtestBitcoinEnv --publish 18443:18443 --publish 18444:18444 --publish 3002:3002 --publish 3003:3003 --publish 60401:60401 localhost/regtest:v1.1.0
-podman start RegtestBitcoinEnv
+```
 
+```shell
 # Using the container
 cd ~/podman/regtest-in-a-pod/
 podman machine start regtest

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ It allows you to create a robust regtest environment which you can turn on and o
 3. An Electrum server
 4. An Esplora server
 5. A block explorer
-6. Useful aliases and just commands for working with the daemon from your command line
+6. Useful just commands for working with the daemon from your command line
 
 Read the article linked above for all the information on how to use the container to its fullest, but here is a quick cheatsheet:
 
 ## Usage
-You can use the aliases defined in the `aliases.sh` file directly, but even better is to use the [`just`](https://github.com/casey/just) tool and leverage the commands defined in the `justfile`.
+You can use the [`just`](https://github.com/casey/just) tool and leverage the commands defined in the `justfile`.
 
 ```shell
 just mine 21
@@ -29,18 +29,18 @@ podman machine start regtest
 podman --connection regtest build --tag localhost/regtest:v1.0.0 --file ./Containerfile
 podman create --name RegtestBitcoinEnv --publish 18443:18443 --publish 18444:18444 --publish 3002:3002 --publish 3003:3003 --publish 60401:60401 localhost/regtest:v1.1.0
 podman start RegtestBitcoinEnv
-source aliases.sh
 
 # Using the container
 cd ~/podman/regtest-in-a-pod/
 podman machine start regtest
 podman start RegtestBitcoinEnv
-source aliases.sh
-# podmine
-# podcli
-# explorer
+# mine 4 blocks
+just mine 4
+# execute bitcoin-cli command directly in pod
+just cli getnetworkinfo
+# launch block explorer
+just explorer
 
-# Stopping the container and the machine
-podman stop RegtestBitcoinEnv
-podman machine stop regtest
+# Stop the container and the machine
+just stop
 ```


### PR DESCRIPTION
### Description

`aliases.sh` file was removed from the repository in commit 69df324d6c88b54a922ae9baab203c6e400a8ee5, but some references to it are still around in documentation.

This change removes them to avoid confusion for future readers.
