### PR TITLE
Add --connection flag to all just commands to avoid ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ just esploralogs
 cd ~/podman/regtest-in-a-pod/
 podman machine start regtest
 podman --connection regtest build --tag localhost/regtest:v1.0.0 --file ./Containerfile
-podman create --name RegtestBitcoinEnv --publish 18443:18443 --publish 18444:18444 --publish 3002:3002 --publish 3003:3003 --publish 60401:60401 localhost/regtest:v1.1.0
+podman --connection regtest create --name RegtestBitcoinEnv --publish 18443:18443 --publish 18444:18444 --publish 3002:3002 --publish 3003:3003 --publish 60401:60401 localhost/regtest:v1.1.0
 ```
 
 ```shell
 # Using the container
 cd ~/podman/regtest-in-a-pod/
 podman machine start regtest
-podman start RegtestBitcoinEnv
+podman --connection regtest start RegtestBitcoinEnv
 # mine 4 blocks
 just mine 4
 # execute bitcoin-cli command directly in pod

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@
 [group("Bitcoin Core")]
 [doc("Print the current session cookie to console.")]
 @cookie:
-  podman exec RegtestBitcoinEnv cat /root/.bitcoin/regtest/.cookie | cut -d ':' -f2
+  podman --connection regtest exec RegtestBitcoinEnv cat /root/.bitcoin/regtest/.cookie | cut -d ':' -f2
 
 [group("Bitcoin Core")]
 [doc("Mine a block, or mine <BLOCKS> number of blocks.")]
@@ -26,39 +26,39 @@
 [group("Logs")]
 [doc("Print all logs to console.")]
 logs:
-  podman logs RegtestBitcoinEnv
+  podman --connection regtest logs RegtestBitcoinEnv
 
 [group("Logs")]
 [doc("Print bitcoin daemon logs to console.")]
 bitcoindlogs:
-  podman exec -it RegtestBitcoinEnv tail -f /root/log/bitcoin.log
+  podman --connection regtest exec -it RegtestBitcoinEnv tail -f /root/log/bitcoin.log
 
 [group("Logs")]
 [doc("Print Esplora logs to console.")]
 esploralogs:
-  podman exec -it RegtestBitcoinEnv tail -f /root/log/esplora.log
+  podman --connection regtest exec -it RegtestBitcoinEnv tail -f /root/log/esplora.log
 
 [group("Logs")]
 [doc("Print block explorer logs to console.")]
 explorerlogs:
-  podman exec -it RegtestBitcoinEnv tail -f /root/log/fbbe.log
+  podman --connection regtest exec -it RegtestBitcoinEnv tail -f /root/log/fbbe.log
 
 [group("Podman")]
 [doc("Start your podman machine and regtest environment.")]
 start:
   podman machine start regtest
-  podman start RegtestBitcoinEnv
+  podman --connection regtest start RegtestBitcoinEnv
 
 [group("Podman")]
 [doc("Stop your podman machine and regtest environment.")]
 stop:
-  podman stop RegtestBitcoinEnv
+  podman --connection regtest stop RegtestBitcoinEnv
   podman machine stop regtest
 
 [group("Podman")]
 [doc("Enter the shell in the pod.")]
 podshell:
-  podman exec -it RegtestBitcoinEnv /bin/bash
+  podman --connection regtest exec -it RegtestBitcoinEnv /bin/bash
 
 [group("Podman")]
 [doc("Open the block explorer.")]


### PR DESCRIPTION
### Description

In the [blog explaining the setup](https://thunderbiscuit.com/posts/podman-bitcoin/) of this repository it was mentioned that `podman system connection default regtest` will set the default connection to the regtest VM, however, it seems the command is not working properly or there are some missing nuances for it.

To avoid confusion for users with errors, I think is better to explicitly recommend and use the  `--connection` flag in all `podman` commands that need it.

Fixes #2