### PR TITLE
Enable config of bitcoin-core version and architecture at buildtime

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,8 +4,9 @@ FROM debian:bookworm
 RUN apt-get update && apt-get install -y wget
 
 # Setup bitcoin core binaries download
-ENV BITCOIN_VERSION=26.0
-ENV BITCOIN_TARBALL=bitcoin-${BITCOIN_VERSION}-aarch64-linux-gnu.tar.gz
+ARG BITCOIN_VERSION=26.0
+ARG TARGET_ARCH=aarch64
+ENV BITCOIN_TARBALL=bitcoin-${BITCOIN_VERSION}-${TARGET_ARCH}.tar.gz
 ENV BITCOIN_URL=https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/${BITCOIN_TARBALL}
 
 # Install bitcoin core

--- a/README.md
+++ b/README.md
@@ -26,22 +26,21 @@ just esploralogs
 # Building the container
 cd ~/podman/regtest-in-a-pod/
 podman machine start regtest
-podman --connection regtest build --tag localhost/regtest:v1.0.0 --file ./Containerfile
+# Set BITCOIN_VERSION and TARGET_ARCH to use the bitcoin core versions you need
+podman --connection regtest build --build-arg BITCOIN_VERSION=28.1 --build-arg TARGET_ARCH=x86_64-linux-gnu --tag localhost/regtest:v1.0.0 --file ./Containerfile
 podman --connection regtest create --name RegtestBitcoinEnv --publish 18443:18443 --publish 18444:18444 --publish 3002:3002 --publish 3003:3003 --publish 60401:60401 localhost/regtest:v1.1.0
-```
 
-```shell
 # Using the container
-cd ~/podman/regtest-in-a-pod/
-podman machine start regtest
-podman --connection regtest start RegtestBitcoinEnv
-# mine 4 blocks
+# Start the machine + pod
+just start
+# List all available just commands
+just
+# Mine 4 blocks
 just mine 4
-# execute bitcoin-cli command directly in pod
+# Execute bitcoin-cli command directly in pod
 just cli getnetworkinfo
-# launch block explorer
+# Launch block explorer
 just explorer
-
 # Stop the container and the machine
 just stop
 ```


### PR DESCRIPTION
### Description

The [blog](https://thunderbiscuit.com/posts/podman-bitcoin/) doesn't mention the need to adapt the script to your architecture. Although it can be deducted, I think is easier to explicitly tell in which steps user interaction is required.

This change explicitly includes bitcoin-core versions and target architecture as parameter of the building step, allowing more flexibility at the moment of building the image.

Documentation has been adapted accordingly to show the user how these parameter can be changed to produce the desired image.

Fixes #4 