### PR TITLE
Correcting the filename in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y wget
 
 # Setup bitcoin core binaries download
 ARG BITCOIN_VERSION=26.0
-ARG TARGET_ARCH=aarch64
+ARG TARGET_ARCH=aarch64-linux-gnu
 ENV BITCOIN_TARBALL=bitcoin-${BITCOIN_VERSION}-${TARGET_ARCH}.tar.gz
 ENV BITCOIN_URL=https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/${BITCOIN_TARBALL}
 


### PR DESCRIPTION
When walking through the blog post on this regtest solution, I hit on the issue of the bitcoin download pointing to a bad filename.  I changed it in my fork and it works now.

Reference gh issue:
https://github.com/thunderbiscuit/regtest-in-a-pod/issues/7#issue-2958295175